### PR TITLE
Fix managed identity auth: use identity name as PG username

### DIFF
--- a/lfa2-backend/db-interface.js
+++ b/lfa2-backend/db-interface.js
@@ -17,7 +17,7 @@ async function createPool() {
     const { DefaultAzureCredential } = require('@azure/identity')
     const credential = new DefaultAzureCredential()
     const token = await credential.getToken('https://ossrdbms-aad.database.windows.net/.default')
-    baseConfig.user = process.env.AZURE_CLIENT_ID
+    baseConfig.user = process.env.AZURE_IDENTITY_NAME || 'lfa-backend-identity'
     baseConfig.password = token.token
     console.log('Auth mode: managed-identity')
   } else {


### PR DESCRIPTION
PostgreSQL Entra auth requires the identity name (e.g. lfa-backend-identity) as the username, not the client ID GUID. AZURE_CLIENT_ID is still set in the environment for DefaultAzureCredential to select the right identity.